### PR TITLE
replace urlValidator with urlToSearch

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -7,7 +7,7 @@ import FeedbackComponent from './FeedbackComponent.js';
 import LoggingService from '../../services/LoggingService.js';
 import { GcdsTextarea, GcdsButton, GcdsDetails } from '@cdssnc/gcds-components-react';
 import '../../styles/App.css';
-import { urlValidator } from '../../utils/urlValidator.js';
+import { urlToSearch } from '../../utils/urlToSearch.js';
 import { useTranslations } from '../../hooks/useTranslations.js';
 import { usePageContext, DEPARTMENT_MAPPINGS } from '../../hooks/usePageParam.js';
 import DepartmentSelectorTesting from './DepartmentSelectorTesting';
@@ -373,7 +373,13 @@ const ChatAppContainer = ({ lang = 'en' }) => {
         // Validate URL if present
         let finalCitationUrl, confidenceRating;
         if (originalCitationUrl) {
-          const validationResult = await urlValidator.validateAndCheckUrl(originalCitationUrl, lang, t);
+          const validationResult = await urlToSearch.validateAndCheckUrl(
+            originalCitationUrl, 
+            lang, 
+            redactedText,  // Changed from userMessage to redactedText
+            selectedDepartment,
+            t
+          );
           
           // Store validation result in checkedCitations using the new message ID
           setCheckedCitations(prev => ({
@@ -634,8 +640,8 @@ const ChatAppContainer = ({ lang = 'en' }) => {
             </div>
 
             {/* Add department selector here with label */}
-            <div class="mrgn-bttm-10">
-              <label class="display-block mrgn-bttm-4">Referred from:</label>
+            <div className="mrgn-bttm-10">
+              <label className="display-block mrgn-bttm-4">Referred from:</label>
               <DepartmentSelectorTesting
                 selectedDepartment={selectedDepartment}
                 onDepartmentChange={handleDepartmentChange}
@@ -643,7 +649,7 @@ const ChatAppContainer = ({ lang = 'en' }) => {
               />
             </div>
 
-            <div class="mrgn-bttm-10">
+            <div className="mrgn-bttm-10">
               <label htmlFor="referring-url">{t('homepage.chat.options.referringUrl.label')}</label>
               <input
                 id="referring-url"

--- a/src/utils/urlToSearch.js
+++ b/src/utils/urlToSearch.js
@@ -1,0 +1,69 @@
+import checkCitationUrl from './urlChecker';
+
+/**
+ * URLToSearch class provides methods to validate and verify URLs for Canada.ca domains
+ * Valid canada.ca urls are checked for 404 and if not, returned with high confidence 
+ * If not a valid canada.ca url, a search url is prepared based on department and returned with low confidence
+ */
+class URLToSearch {
+
+  /**
+   * Validate and check URL accessibility
+   * @param {string} url - URL to validate and check
+   * @param {string} lang - Language code ('en' or 'fr')
+   * @param {string} question - User's question to append to search
+   * @param {string} department - Department code (isc, cra, ircc, or undefined)
+   * @param {function} t - Translation function
+   * @returns {Promise<object>} Validation result with network check
+   */
+  async validateAndCheckUrl(url, lang, question, department, t) {
+    // Function to check if a URL is a Canada.ca domain
+    const isCanadaCaDomain = (url) => {
+      return url.startsWith('https://www.canada.ca') || url.startsWith('http://www.canada.ca');
+    };
+
+    // Only check Canada.ca URLs to see if they are going to 404
+    let checkResult = { isValid: true };
+    if (isCanadaCaDomain(url)) {
+      checkResult = await checkCitationUrl(url);
+    }
+
+    // Only return the URL with high confidence if both conditions are met: valid URL that isn't 404 and Canada.ca domain
+    if (checkResult.isValid && isCanadaCaDomain(url)) {
+      return {
+        isValid: true,
+        url: url,  // Keep the original URL
+        confidenceRating: checkResult.confidenceRating
+      };
+    }
+
+    // Prepare the search URL based on department
+    const encodedQuestion = encodeURIComponent(question);
+    let searchUrl;
+    
+    switch(department?.toLowerCase()) {
+      case 'isc':
+        searchUrl = `https://www.canada.ca/${lang}/indigenous-services-canada/search.html?q=${encodedQuestion}&wb-srch-sub=`;
+        break;
+      case 'cra':
+        searchUrl = `https://www.canada.ca/${lang}/revenue-agency/search.html?q=${encodedQuestion}&wb-srch-sub=`;
+        break;
+      case 'ircc':
+        searchUrl = `https://www.canada.ca/${lang}/services/immigration-citizenship/search.html?q=${encodedQuestion}&wb-srch-sub=`;
+        break;
+      default:
+        searchUrl = `https://www.canada.ca/${lang}/sr/srb.html?q=${encodedQuestion}&wb-srch-sub=`;
+    }
+
+    return {
+      isValid: false,
+      fallbackUrl: searchUrl,
+      fallbackText: t('homepage.chat.citation.fallbackText'),
+      confidenceRating: '0.1'
+    };
+  }
+
+};
+  
+// Export a singleton instance
+export const urlToSearch = new URLToSearch();


### PR DESCRIPTION
replace urlValidator with urlToSearch
If not a canada.ca domain (because can't check them for 404) OR is a canada.ca domain that does 404, append user search query to search instead.
I have given up for now on trying to fix the citation link provided by the AI by ‘walking up the menu’ etc. It just wasn’t working. In addition, I wasn’t able to check if [non-canada.ca](http://non-canada.ca/) urls were going to 404 errors, and quite often they were. So what I’ve done for now (until we can get the search api swapping in the right URL), is to simply add the search query to the search url, so your citation link takes you to the search result page with the query already filled in. If you pre-selected departments CRA, ISC or IRCC, it loads that custom search, otherwise its just plain [canada.ca](http://canada.ca/) search results.
So now you will never get a 404 result at all - you’ll either get a valid [canada.ca](http://canada.ca/) url OR the citation link hikes you off to the search results page with your question filled in. It’s a bit bizarre for the user, but better than 404 and will help find recent additions. This is hopefully temporary.
