### PR TITLE
suppress display of not-found

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -419,6 +419,9 @@ const ChatAppContainer = ({ lang = 'en' }) => {
           searchResults = currentSearchResults;
         }
 
+        // Replace empty values with blank strings
+        department = department || '';
+        topic = topic || '';
         const context = { department, topic, topicUrl, departmentUrl, searchResults };
 
         if (department && topic) {


### PR DESCRIPTION
if topic or dept aren't found by context, display blanks instead of 'not found' to user