### PR TITLE
prioritize over search results

### DIFF
--- a/src/services/systemPrompt/citationInstructions.js
+++ b/src/services/systemPrompt/citationInstructions.js
@@ -1,6 +1,6 @@
 export const CITATION_INSTRUCTIONS = `
 ## CITATION INSTRUCTIONS
-When answering based on Canada.ca or gc.ca content, your response will include a citation link selected and formattedaccording to these instructions: 
+When answering based on Canada.ca or gc.ca content, your response must include a citation link selected and formatted according to these instructions: 
 
 ### Citation Input Context
 Use the following information to select the most relevant citation link:
@@ -11,34 +11,32 @@ Use the following information to select the most relevant citation link:
 - <department> (if found by the earlier AI service)
 - <departmentUrl> (if found by the earlier AI service)
 - <referring-url> (if found - this is the page the user was on when they asked their question)
-- <possible-citations> possible citation urls in English and French from the scenarios and updatesprovided in this prompt
-   - Prioritize the possible citations over other possible citations particularly over the <searchResults> if present.
-- <searchResults>search results</searchResults> (if found by the earlier AI service) - use searchResults data to:
-      - Identify possible citation urls, particularly if the page-language is French
+- <searchResults> use searchResults data to:
+      - Identify possible citation urls, particularly if the page-language is French, noting that some search results may be to the incorrect pages (for example, this page https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/prepare-arrival.html is ONLY for people arriving in Canada with a visitor visa, not for other travellers)
       - Verify the accuracy of a possible citation url
       - Find alternative URLs when primary sources fail verification
+- <possible-citations> possible citation urls in English and French from the scenarios and updates provided in this prompt
+   - Always prioritize citations from the scenarios and updates over the <searchResults> 
 
 ### Citation Selection Rules
 1. Select ONE English canada.ca or gc.ca URL that best serves the user's next step or directly answers their question, or if the official <page-language> is French, always use the matching official French canada.ca or gc.ca URL.
-   - When choosing between URLs, always prefer broader, verified URLs over specific URLs that you cannot confirm
+   - When choosing between URLs, always prefer broader, verified URLs and URLS from the scenarios and updates over specific URLs that you cannot confirm
 2. Prioritize the user's next logical step over direct sources or the referring url
    Example: For application form questions, provide the eligibility or application page link if there is one,rather than linking a specific application form.
-   Example: For questions about renewing a passport where the referring url is the passport renewal page, provide the passport renewal page link again if that's the best answer
+   Example: For questions about renewing a passport where the referring url is the passport renewal page, provide the passport renewal page link again if that's the best answer or provide a link to a different step in the passport renewal process
 3. When choosing a citation url, it MUST:
 - Use https://
-- Include canada.ca or gc.ca or the department or agency provided in the <department> tag
+- Include canada.ca or gc.ca or <departmentUrl> 
 - Be production URLs only
 - Follow standard URL formatting
 - Be checked by using the "checkUrl", it MUST return live
 4. When uncertain about the validity of a citation url or unable to find an exact match, follow this fallback hierarchy:
-   a. Use a url from scenarios and updates in this prompt, or <referring-url> or a <searchResults> url if it:
-      - Is available AND
-      - Contains the information that answers the user's question
-    b. If none are suitable, use any relevant canada.ca URL found in the breadcrumb trail that leads toward the answer
-   c. As a last resort, use the<departmentURL> if available
+   a. use any relevant canada.ca URL found in the breadcrumb trail that leads toward the answer
+   b. use the most relevant canada.ca theme page url (theme page urls all start with https://www.canada.ca/en/services/ or https://www.canada.ca/fr/services/)
+   c. use <departmentURL> if available
 
 ### URL Verification Process:
-   a. MUST verify ALL URLs using the "checkUrl" tool before responding
+   a. MUST verify proposed URLs using the "checkUrl" tool before responding
    b. If a URL fails verification:
       - Try up to 5 alternative URLs
       - Move to the next level in the fallback hierarchy if no alternatives work


### PR DESCRIPTION
having trouble with search result citations being used instead of citations in the scenarios 
- particulalry for IRCC where double h1 pages are being cited that are limited to a specific group 
- eg. https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/prepare-arrival.html when this page is ONLY for people entering with visas 
and https://www.canada.ca/en/immigration-refugees-citizenship/services/visit-canada/entry-requirements-country.html instead of find out if you need a visa