### PR TITLE
Dept force

### DIFF
--- a/src/services/contextSystemPrompt.js
+++ b/src/services/contextSystemPrompt.js
@@ -45,7 +45,7 @@ async function loadContextSystemPrompt(language = 'en', department = '') {
 
     const fullPrompt = `
       ## Role
-      You are a context analyzer for the AI Answers application on Canada.ca. Your role is to strictly match user questions to departments listed in the departments_list section below, following a specific matching algorithm.
+      You are a department matching expert for the AI Answers application on Canada.ca. Your role is to match user questions to departments listed in the departments_list section below, following a specific matching algorithm. This will help narrow in to the department most likely to hold the answer to the user's question.
 
       ${language === 'fr' 
         ? `## Language Context: French
@@ -54,27 +54,29 @@ async function loadContextSystemPrompt(language = 'en', department = '') {
         User asked their question on the official English AI Answers page`}
 
 <departments_list>
-## Complete list of government of Canada departments and agencies with name, url, and abbreviation, in the official language context. - MUST SELECT FROM THIS LIST 
+## Complete list of Government of Canada departments and agencies with name, url, and abbreviation, in the official language context. - MUST SELECT FROM THIS LIST 
   ${departmentsString}
 </departments_list> 
 
 ## Matching Algorithm:
 1. Extract key topics and entities from the user's question and message
-2. Prioritize your analysis of the question and <referring-url> which is the page they were on when they invoked AI Answers, and conversation history over the <searchResults>. 
-2. Compare ONLY against departments in the <departments_list> above
+- Prioritize your analysis of the question and context over the <searchResults> 
+- <referring-url> often identifies the department in a segment but occasionally may betray a misunderstanding. For example, the user may be on the MSCA sign in page but their question is how to sign in to get their Notice of Assessment, which is done through their CRA account.
+2. Compare ONLY against departments in the <departments_list> 
 3. DO NOT match to programs, benefits, or services - only match to their administering department
 4. If multiple departments could be responsible:
-   - Select the department that directly administers the program/service
-   - Do not select departments that only provide information about it
+   - Select the department that directly administers and delivers web content for the program/service
 5. If no clear department match exists, return empty values
 
 ## Examples of Program-to-Department Mapping:
 - Canada Pension Plan (CPP) → ESDC (administering department)
-- GST/HST Credit → CRA (administering department)
 - Canada Child Benefit → CRA (administering department)
-- Employment Insurance → ESDC (administering department)
+- Apprenticeships → ESDC (administering department)
+- EI → ESDC (administering department)
 - Weather Forecasts → ECCC (administering department)
 - My Service Canada Account → ESDC (administering department)
+- Visa, ETA, entry to Canada → IRCC (administering department)
+- Ontario Trillium Benefit → CRA (administering department)
 
 ## Response Format:
 <analysis>
@@ -82,6 +84,7 @@ async function loadContextSystemPrompt(language = 'en', department = '') {
 <departmentUrl>[EXACT matching URL from list OR empty string]</departmentUrl>
 </analysis>
 
+## Examples:
 <examples>
 <example>
 * A question about the weather forecast would match:
@@ -96,22 +99,6 @@ async function loadContextSystemPrompt(language = 'en', department = '') {
 <analysis>
 <department></department>
 <departmentUrl></departmentUrl>
-</analysis>
-</example>
-
-<example>
-* A question about GST/HST credit would match:
-<analysis>
-<department>CRA</department>
-<departmentUrl>https://www.canada.ca/en/revenue-agency.html</departmentUrl>
-</analysis>
-</example>
-
-<example>
-* A question about the Ontario Trillium Benefit administered by the CRA would match:
-<analysis>
-<department>CRA</department>
-<departmentUrl>https://www.canada.ca/en/revenue-agency.html</departmentUrl>
 </analysis>
 </example>
 

--- a/src/services/systemPrompt/agenticBase.js
+++ b/src/services/systemPrompt/agenticBase.js
@@ -64,23 +64,19 @@ export const BASE_SYSTEM_PROMPT = `
 4. For questions that have multiple answer options, include all of the options in the response. For example, if the question is about how to apply for CPP, the response would identify that the user can apply online through the My Service Canada account OR by using the paper form. 
 
 #### Asking Clarifying Questions in a conversation
-* If it will help clarify the answer and only if the user's question is not wrapped in <evaluation> tags, ask a clarifying question before answering. Wrap the question in <clarifying-question> and </clarifying-question> tags. No citation link is needed for the clarifying question. No apologies.
-* When you see messages with these tags in the conversation history:
-  - <clarifying-question>...</clarifying-question>: This indicates you previously asked for clarification and you should use the user's answer to provide a complete response that addresses their original query.
-- <not-gc>...</not-gc>: This indicates content about non-government services
-- <pt-muni>...</pt-muni>: This indicates provincial/municipal content
-Use these tags to understand the context of the conversation and provide appropriate follow-up responses. 
-The responses must follow the Response structure format listed above.
+* Any time it will help clarify the answer, and only if the user's question is not wrapped in <evaluation> tags, ask a clarifying question before answering. 
+- IMPORTANT: ask the question in <question-language> -the language of the user's question. 
+- Wrap the question in <clarifying-question> and </clarifying-question> tags. 
+- No citation link is needed for the clarifying question. No apologies..
 
 ### Updated Information Handling
 * For certain departments, you will be provided with updated information ans specific scenarios within this prompt. Always prioritize and use this provided information and citation links over any conflicting knowledge from your training data.
 * Prioritize information from the most recently updated sources. If you encounter conflicting information, defer to the content from the page with the most recent 'Date modified'. Avoid providing information from pages labelled as archived. 
 
 ### Personal Information and inappropriate content
-* Filtering for personal information, threats, obscenity, and manipulation is performed in advance. A message is displayed to the user that the question was not sent to the AI service, and they should ask the question again without personal information.
+* Filtering for personal information, threats, obscenity, and manipulation is performed in advance. 
 * If the question accidentally includes unredacted personal information or other inappropriate content, do not include it in your response. 
-* Respond to inappropriate content with a simple response in the language of the user's question like 'Try a different question. That's not something this Government of Canada service will answer.'.
-
+* Respond to inappropriate questions with a simple response in the language of the user's question like 'Try a different question. That's not something this Government of Canada service will answer.'.
 
 ### Federal, Provincial, Territorial, or Municipal Matters
 1. For topics that could involve both federal and provincial/territorial/municipal jurisdictions, such as incorporating a business, or healthcare for indigenous communities in the north or transport etc.:

--- a/src/services/systemPrompt/departments_EN.js
+++ b/src/services/systemPrompt/departments_EN.js
@@ -35,7 +35,7 @@ export const departments_EN = [
   },
   {
     "name": "Bank of Canada",
-    "url": "https: //www.bankofcanada.ca/",
+    "url": "https://www.bankofcanada.ca/",
     "abbr": null
   },
   {
@@ -65,7 +65,7 @@ export const departments_EN = [
   },
   {
     "name": "Canada Border Services Agency",
-    "url": "https: //www.cbsa-asfc.gc.ca/menu-eng.html",
+    "url": "https://www.cbsa-asfc.gc.ca/menu-eng.html",
     "abbr": "CBSA"
   },
   {
@@ -165,7 +165,7 @@ export const departments_EN = [
   },
   {
     "name": "Canadian Centre for Occupational Health and Safety",
-    "url": "https: //www.ccohs.ca/",
+    "url": "https://www.ccohs.ca/",
     "abbr": "CCOHS"
   },
   {
@@ -255,7 +255,7 @@ export const departments_EN = [
   },
   {
     "name": "Canadian Intergovernmental Conference Secretariat",
-    "url": "https: //www.scics.ca/en/",
+    "url": "https://www.scics.ca/en/",
     "abbr": "CICS"
   },
   {
@@ -275,27 +275,27 @@ export const departments_EN = [
   },
   {
     "name": "Canadian Museum of History",
-    "url": "https: //www.historymuseum.ca/",
+    "url": "https://www.historymuseum.ca/",
     "abbr": "CMH"
   },
   {
     "name": "Canadian Museum of Immigration at Pier 21",
-    "url": "https: //www.pier21.ca/home",
+    "url": "https://www.pier21.ca/home",
     "abbr": "CMIP"
   },
   {
     "name": "Canadian Museum of Nature",
-    "url": "https: //nature.ca/en/home",
+    "url": "https://nature.ca/en/home",
     "abbr": "CMN"
   },
   {
     "name": "Canadian Northern Economic Development Agency",
-    "url": "https: //www.cannor.gc.ca/eng/1351104567432/1351104589057",
+    "url": "https://www.cannor.gc.ca/eng/1351104567432/1351104589057",
     "abbr": "CanNor"
   },
   {
     "name": "Canadian Nuclear Safety Commission",
-    "url": "https: //www.nuclearsafety.gc.ca/eng/",
+    "url": "https://www.nuclearsafety.gc.ca/eng/",
     "abbr": "CNSC"
   },
   {
@@ -310,12 +310,12 @@ export const departments_EN = [
   },
   {
     "name": "Canadian Race Relations Foundation",
-    "url": "https: //www.crrf-fcrr.ca/en/",
+    "url": "https://www.crrf-fcrr.ca/en/",
     "abbr": "CRRF"
   },
   {
     "name": "Canadian Radio-Television and Telecommunications Commission",
-    "url": "https: //www.crtc.gc.ca/eng/home-accueil.htm",
+    "url": "https://www.crtc.gc.ca/eng/home-accueil.htm",
     "abbr": "CRTC"
   },
   {
@@ -340,7 +340,7 @@ export const departments_EN = [
   },
   {
     "name": "Canadian Trade Commissioner Service",
-    "url": "https: //tradecommissioner.gc.ca/index.aspx?lang=eng",
+    "url": "https://tradecommissioner.gc.ca/index.aspx?lang=eng",
     "abbr": "TCS"
   },
   {
@@ -350,12 +350,12 @@ export const departments_EN = [
   },
   {
     "name": "Canadian War Museum",
-    "url": "https: //www.warmuseum.ca/",
+    "url": "https://www.warmuseum.ca/",
     "abbr": null
   },
   {
     "name": "CBC/Radio-Canada",
-    "url": "https: //www.cbc.radio-canada.ca/en/",
+    "url": "https://www.cbc.radio-canada.ca/en/",
     "abbr": "CBC"
   },
   {
@@ -365,7 +365,7 @@ export const departments_EN = [
   },
   {
     "name": "Commissioner for Federal Judicial Affairs Canada (Office of the)",
-    "url": "https: //www.fja.gc.ca/home-accueil/index-eng.html",
+    "url": "https://www.fja.gc.ca/home-accueil/index-eng.html",
     "abbr": "FJA"
   },
   {
@@ -430,7 +430,7 @@ export const departments_EN = [
   },
   {
     "name": "Courts Administration Service",
-    "url": "https: //www.cas-satj.gc.ca/en/home.shtml",
+    "url": "https://www.cas-satj.gc.ca/en/home.shtml",
     "abbr": "CAS"
   },
   {
@@ -445,7 +445,7 @@ export const departments_EN = [
   },
   {
     "name": "Bank of Canada Museum",
-    "url": "https: //www.bankofcanadamuseum.ca/",
+    "url": "https://www.bankofcanadamuseum.ca/",
     "abbr": null
   },
   {
@@ -475,7 +475,7 @@ export const departments_EN = [
   },
   {
     "name": "Elections Canada",
-    "url": "https: //www.elections.ca/home.aspx",
+    "url": "https://www.elections.ca/home.aspx",
     "abbr": "Elections"
   },
   {
@@ -510,7 +510,7 @@ export const departments_EN = [
   },
   {
     "name": "Federal Bridge Corporation",
-    "url": "https: //www.federalbridge.ca/",
+    "url": "https://www.federalbridge.ca/",
     "abbr": "FBCL"
   },
   {
@@ -555,12 +555,12 @@ export const departments_EN = [
   },
   {
     "name": "Fisheries and Oceans Canada",
-    "url": "https: //www.dfo-mpo.gc.ca/index-eng.htm",
+    "url": "https://www.dfo-mpo.gc.ca/index-eng.htm",
     "abbr": "DFO"
   },
   {
     "name": "Freshwater Fish Marketing Corporation",
-    "url": "https: //www.freshwaterfish.com/",
+    "url": "https://www.freshwaterfish.com/",
     "abbr": "FFMC"
   },
   {
@@ -620,7 +620,7 @@ export const departments_EN = [
   },
   {
     "name": "Indian Oil and Gas Canada",
-    "url": "https: //www.pgic-iogc.gc.ca/eng/1100110010002/1100110010005",
+    "url": "https://www.pgic-iogc.gc.ca/eng/1100110010002/1100110010005",
     "abbr": null
   },
   {
@@ -665,7 +665,7 @@ export const departments_EN = [
   },
   {
     "name": "Judicial Compensation and Benefits Commission",
-    "url": "https: //quadcom.gc.ca/pg_JcJc_QC_01-eng.php",
+    "url": "https://quadcom.gc.ca/pg_JcJc_QC_01-eng.php",
     "abbr": null
   },
   {
@@ -680,7 +680,7 @@ export const departments_EN = [
   },
   {
     "name": "Laurentian Pilotage Authority Canada",
-    "url": "https: //www.pilotagestlaurent.gc.ca/en/index.html",
+    "url": "https://www.pilotagestlaurent.gc.ca/en/index.html",
     "abbr": "LPA"
   },
   {
@@ -705,7 +705,7 @@ export const departments_EN = [
   },
   {
     "name": "Marine Atlantic",
-    "url": "https: //www.marineatlantic.ca/en/",
+    "url": "https://www.marineatlantic.ca/en/",
     "abbr": "MarineAtlantic"
   },
   {
@@ -725,7 +725,7 @@ export const departments_EN = [
   },
   {
     "name": "National Arts Centre",
-    "url": "https: //nac-cna.ca/en/",
+    "url": "https://nac-cna.ca/en/",
     "abbr": "NAC"
   },
   {
@@ -735,7 +735,7 @@ export const departments_EN = [
   },
   {
     "name": "National Capital Commission",
-    "url": "https: //www.ncc-ccn.gc.ca/",
+    "url": "https://www.ncc-ccn.gc.ca/",
     "abbr": "NCC"
   },
   {
@@ -760,7 +760,7 @@ export const departments_EN = [
   },
   {
     "name": "National Gallery of Canada",
-    "url": "https: //www.gallery.ca/",
+    "url": "https://www.gallery.ca/",
     "abbr": "NGC"
   },
   {
@@ -825,7 +825,7 @@ export const departments_EN = [
   },
   {
     "name": "Parliament of Canada",
-    "url": "https: //www.parl.ca/?Language=E",
+    "url": "https://www.parl.ca/?Language=E",
     "abbr": null
   },
   {
@@ -850,7 +850,7 @@ export const departments_EN = [
   },
   {
     "name": "Prime Minister of Canada",
-    "url": "https: //pm.gc.ca/eng",
+    "url": "https://pm.gc.ca/eng",
     "abbr": null
   },
   {
@@ -875,7 +875,7 @@ export const departments_EN = [
   },
   {
     "name": "Public Prosecution Service of Canada",
-    "url": "https: //www.ppsc-sppc.gc.ca/eng/index.html",
+    "url": "https://www.ppsc-sppc.gc.ca/eng/index.html",
     "abbr": "PPSC"
   },
   {
@@ -930,7 +930,7 @@ export const departments_EN = [
   },
   {
     "name": "Royal Canadian Mounted Police",
-    "url": "https: //www.rcmp-grc.gc.ca/en/home",
+    "url": "https://www.rcmp-grc.gc.ca/en/home",
     "abbr": "RCMP"
   },
   {
@@ -952,11 +952,6 @@ export const departments_EN = [
     "name": "Secretariat of the National Security and Intelligence Committee of Parliamentarians",
     "url": "https://www.canada.ca/en/secretariat-national-security-intelligence-committee-parliamentarians.html",
     "abbr": "NSICOP"
-  },
-  {
-    "name": "Service Canada",
-    "url": "https://www.canada.ca/en/employment-social-development/corporate/portfolio/service-canada.html",
-    "abbr": "ServCan"
   },
   {
     "name": "Shared Services Canada",
@@ -1000,7 +995,7 @@ export const departments_EN = [
   },
   {
     "name": "Supreme Court of Canada",
-    "url": "https: //www.scc-csc.ca/home-accueil/index-eng.aspx",
+    "url": "https://www.scc-csc.ca/home-accueil/index-eng.aspx",
     "abbr": "SCC"
   },
   {
@@ -1015,7 +1010,7 @@ export const departments_EN = [
   },
   {
     "name": "Telefilm Canada",
-    "url": "https: //www.telefilm.ca/en/?q=en",
+    "url": "https://www.telefilm.ca/en/?q=en",
     "abbr": null
   },
   {
@@ -1060,7 +1055,7 @@ export const departments_EN = [
   },
   {
     "name": "VIA Rail Canada",
-    "url": "https: //www.viarail.ca/en",
+    "url": "https://www.viarail.ca/en",
     "abbr": "VIA Rail"
   },
   {

--- a/src/services/systemPrompt/departments_FR.js
+++ b/src/services/systemPrompt/departments_FR.js
@@ -55,7 +55,7 @@ export const departments_FR = [
   },
   {
     "name": "Agence canadienne de développement économique du Nord",
-    "url": "https: //www.cannor.gc.ca/fra/1351104567432/1351104589057",
+    "url": "https://www.cannor.gc.ca/fra/1351104567432/1351104589057",
     "abbr": "CanNor"
   },
   {
@@ -210,7 +210,7 @@ export const departments_FR = [
   },
   {
     "name": "Centre canadien d'hygiène et de sécurité au travail",
-    "url": "https: //www.cchst.ca/",
+    "url": "https://www.cchst.ca/",
     "abbr": "CCHST"
   },
   {
@@ -250,12 +250,12 @@ export const departments_FR = [
   },
   {
     "name": "Centre national des arts",
-    "url": "https: //nac-cna.ca/fr/",
+    "url": "https://nac-cna.ca/fr/",
     "abbr": "CNA"
   },
   {
     "name": "Chaires de recherche du Canada",
-    "url": "https: //www.chairs-chaires.gc.ca/home-accueil-fra.aspx",
+    "url": "https://www.chairs-chaires.gc.ca/home-accueil-fra.aspx",
     "abbr": null
   },
   {
@@ -285,7 +285,7 @@ export const departments_FR = [
   },
   {
     "name": "Commissariat à la magistrature fédérale Canada",
-    "url": "https: //www.fja.gc.ca/home-accueil/index-fra.html",
+    "url": "https://www.fja.gc.ca/home-accueil/index-fra.html",
     "abbr": "CMF"
   },
   {
@@ -360,7 +360,7 @@ export const departments_FR = [
   },
   {
     "name": "Commission de la capitale nationale",
-    "url": "https: //www.ccn-ncc.gc.ca/",
+    "url": "https://www.ccn-ncc.gc.ca/",
     "abbr": "CCN"
   },
   {

--- a/src/services/systemPrompt/departments_FR.js
+++ b/src/services/systemPrompt/departments_FR.js
@@ -949,11 +949,6 @@ export const departments_FR = [
     "abbr": "SAC"
   },
   {
-    "name": "Service Canada",
-    "url": "https://www.canada.ca/fr/emploi-developpement-social/ministere/portefeuille/service-canada.html",
-    "abbr": "ServCan"
-  },
-  {
     "name": "Service canadien du renseignement de sécurité",
     "url": "https://www.canada.ca/fr/service-renseignement-securite.html",
     "abbr": "SCRS"

--- a/src/services/systemPrompt/scenarios-all.js
+++ b/src/services/systemPrompt/scenarios-all.js
@@ -56,7 +56,7 @@ export const SCENARIOS = `
 * Do not attempt to answer questions about alerts and recalls because they are posted hourly on the Recalls site by multiple departments. Public health notices are not recalls, they are investigations and are not posted on the site -their findings inform the recalls. Always refer people to the Recalls site as the citation for questions about recalls, advisories and safety alerts: http://recalls-rappels.canada.ca/en or https://recalls-rappels.canada.ca/fr
 
 ## Weather forecasts
-* Don't attempt to answer questions about current local weather forecasts because bookmarks to locations may change. Instead teach people to type the name of their town, city, or village into the 'find a location' box at the top of the canada forecast page to find their local weather on https://weather.gc.ca/canada_e.html or https://meteo.gc.ca/canada_f.html
+* Don't provide local weather forecasts or direct links to specific locations. Instead, teach people to type the name of their town, city, or village into the find a location' box (NOT the search box) at the top of this canada forecast page https://weather.gc.ca/canada_e.html or https://meteo.gc.ca/canada_f.html
 
 ## HS NAICS NOC GIFI codes - never provide codes directly in your response, instead provide the citation url to the page with the codes
 * HS codes for 2025 in Canadian Export Classification: https://www150.statcan.gc.ca/n1/pub/65-209-x/65-209-x2025001-eng.htm or https://www150.statcan.gc.ca/n1/pub/65-209-x/65-209-x2025001-fra.htm 


### PR DESCRIPTION
Context service is matching questions to programs instead of departments, which then causes dept content to fail to load. 
Rewrote with tighter rules and examples
Removed ServiceCanada from dept list since it's all on esdc or benefits pages. 