### PR TITLE
update to gpt-4o-latest

### DIFF
--- a/config/ai-models.js
+++ b/config/ai-models.js
@@ -21,14 +21,14 @@ const AI_MODELS = {
     }
   },
   openai: {
-    default: 'gpt-4o-2024-11-20',
+    default: 'gpt-4o-latest',
     models: {
-      'gpt-4o-2024-11-20': {
+      'gpt-4o-latest': {
         maxTokens: 1024,
         temperature: 0.0,
         timeoutMs: 60000,
       },
-      'gpt-4o': {
+      'gpt-4o-latest': {
         maxTokens: 1024,
         temperature: 0.0,
         timeoutMs: 60000,


### PR DESCRIPTION
upgrade to 4o-latest 
@ryanhyma there's a weird exact duplicate in this little section of code:
openai: {
    default: 'gpt-4o-latest',
    models: {
      'gpt-4o-latest': {
        maxTokens: 1024,
        temperature: 0.0,
        timeoutMs: 60000,
      **_},
      'gpt-4o-latest': {
        maxTokens: 1024,
        temperature: 0.0,
        timeoutMs: 60000,
      },_**
      'gpt-4o-mini': {
        maxTokens: 1024,
        temperature: 0.0,
        timeoutMs: 60000,
    }