### PR TITLE
default to 50

### DIFF
--- a/src/pages/ChatViewer.js
+++ b/src/pages/ChatViewer.js
@@ -119,6 +119,7 @@ const ChatViewer = () => {
         ],
         order: [[0, 'desc']],
         scrollX: true, // Enable horizontal scrolling for the whole table
+        pageLength: 50, // Set number of items per page to 50
         // Add styling options for the table
         drawCallback: function () {
           Prism.highlightAll();


### PR DESCRIPTION
chatviewer is currently broken - when I click to go to next page, it just rebuilds the same page - can never see next set. Don't want to make extensive changes, instead just increasing the datatable size from default of 10 to 50.