### PR TITLE
fix-remove-noreferrer

### DIFF
--- a/src/components/chat/ChatAppContainer.js
+++ b/src/components/chat/ChatAppContainer.js
@@ -355,7 +355,7 @@ const ChatAppContainer = ({ lang = 'en', chatId }) => {
             {message.interaction.answer.citationHead && <p key={`${messageId}-head`} className="citation-head">{message.interaction.answer.citationHead}</p>}
             {displayUrl && (
               <p key={`${messageId}-link`} className="citation-link">
-                <a href={displayUrl} target="_blank" rel="noopener noreferrer" tabIndex="0">
+                <a href={displayUrl} target="_blank" rel="noopener" tabIndex="0">
                   {displayUrl}
                 </a>
               </p>


### PR DESCRIPTION
noreferrer on citation links is preventing Analytics from capturing citation link clicks to gc pages. Changed to noopener which still provides some security. 